### PR TITLE
Fix PHP Warning on filter 'sober/intervention/return'

### DIFF
--- a/intervention.php
+++ b/intervention.php
@@ -53,7 +53,7 @@ function getConfigFile()
     $theme . '/intervention.php';
 
     $config = has_filter('sober/intervention/return') ?
-    apply_filters('sober/intervention/return', rtrim($path)) :
+    apply_filters('sober/intervention/return', rtrim($default)) :
     $default;
 
     if (!file_exists($config)) {


### PR DESCRIPTION
Hello Darren,

This PR fixes a PHP Warning

Steps to reproduce:
- When I have a filter on `sober/intervention/return`
- Then I have a PHP Warning: `Undefined variable $path in (...)/intervention/intervention.php on line 56`

Bests regards,
Pierre