### PR TITLE
Fix emoji remove

### DIFF
--- a/src/Application/Writing.php
+++ b/src/Application/Writing.php
@@ -57,7 +57,7 @@ class Writing
         add_action('admin_head-options-writing.php', [$this->api, 'disableKeys']);
 
         if ($this->config->get('writing.emoji') === false) {
-            Emoji::remove();
+            add_action('init', [$this, 'emoji']);
         }
     }
 
@@ -76,5 +76,13 @@ class Writing
             'writing.post-via-email.default-category',
             'writing.update-services',
         ]);
+    }
+
+    /**
+     * Emoji remove
+     */
+    public function emoji()
+    {
+        Emoji::remove();
     }
 }


### PR DESCRIPTION
Emoji remove_actions on wp-admin are called before add_action and don't apply.