### PR TITLE
Fix PHP 8.1 deprecation notice, convert value to string

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -37,7 +37,7 @@ class Str
      */
     public static function explode($delimiter, $value, $limit = PHP_INT_MAX)
     {
-        return Arr::collect(explode($delimiter, $value, $limit));
+        return Arr::collect(explode($delimiter, (string) $value, $limit));
     }
 
     /**


### PR DESCRIPTION
In some situations (not entirely sure which, though) `null` gets passed to the second param of explode here, and that results in a deprecation notice for PHP 8.1. Local environment keeps nagging about this, so would be nice to get a fix in :)